### PR TITLE
Add typewriter hero effect and refine project typings

### DIFF
--- a/src/components/projectCard/ProjectCard.tsx
+++ b/src/components/projectCard/ProjectCard.tsx
@@ -1,7 +1,15 @@
 import styles from "./index.module.scss";
 
+export interface ProjectData {
+  title: string;
+  description: string;
+  demo: string | null;
+  link: string;
+  image: string;
+}
+
 interface Props {
-  data: any;
+  data: ProjectData;
 }
 
 const ProjectCard: React.FC<Props> = (props) => {
@@ -29,7 +37,7 @@ const ProjectCard: React.FC<Props> = (props) => {
               }}
               className={styles.Demo}
             >
-              <a href={data.demo} target="_blank">
+              <a href={data.demo ?? undefined} target="_blank">
                 Link
               </a>
             </button>

--- a/src/components/projectCard/index.tsx
+++ b/src/components/projectCard/index.tsx
@@ -1,3 +1,4 @@
-import ProjectCard from "./ProjectCard";
+import ProjectCard, { ProjectData } from "./ProjectCard";
 
+export type { ProjectData };
 export default ProjectCard;

--- a/src/components/typewriter/Typewriter.tsx
+++ b/src/components/typewriter/Typewriter.tsx
@@ -1,0 +1,29 @@
+import { useEffect, useState } from "react";
+import styles from "./index.module.scss";
+
+interface Props {
+  text: string;
+  speed?: number;
+}
+
+const Typewriter: React.FC<Props> = ({ text, speed = 100 }) => {
+  const [displayedText, setDisplayedText] = useState<string>("");
+
+  useEffect(() => {
+    setDisplayedText("");
+    let i = 0;
+    const interval = setInterval(() => {
+      setDisplayedText((prev) => prev + text.charAt(i));
+      i += 1;
+      if (i >= text.length) {
+        clearInterval(interval);
+      }
+    }, speed);
+
+    return () => clearInterval(interval);
+  }, [text, speed]);
+
+  return <span className={styles.Typewriter}>{displayedText}</span>;
+};
+
+export default Typewriter;

--- a/src/components/typewriter/index.module.scss
+++ b/src/components/typewriter/index.module.scss
@@ -1,0 +1,12 @@
+.Typewriter {
+  border-right: 2px solid currentColor;
+  white-space: nowrap;
+  overflow: hidden;
+  animation: blink 1s steps(1) infinite;
+}
+
+@keyframes blink {
+  50% {
+    border-color: transparent;
+  }
+}

--- a/src/components/typewriter/index.tsx
+++ b/src/components/typewriter/index.tsx
@@ -1,0 +1,3 @@
+import Typewriter from "./Typewriter";
+
+export default Typewriter;

--- a/src/sections/mainSection/MainSection.tsx
+++ b/src/sections/mainSection/MainSection.tsx
@@ -1,5 +1,6 @@
 import styles from "./index.module.scss";
 import { UserData } from "../../userData";
+import Typewriter from "../../components/typewriter";
 
 interface Props {
   myUserData: UserData;
@@ -9,7 +10,7 @@ const MainSection: React.FC<Props> = (props) => {
   const { myUserData } = props;
 
   const searchCV = () =>
-    myUserData.resources.map((item) => item.name === "CV" && item.name);
+    myUserData.resources.find((item) => item.name === "CV")?.name ?? "CV";
 
   const downloadFile = () => {
     const link = document.createElement("a");
@@ -30,7 +31,9 @@ const MainSection: React.FC<Props> = (props) => {
       >{`${myUserData.name} ${myUserData.surname}`}</h1>
       <p className={styles.shortDescription}>
         {" "}
-        <em>{myUserData.slogan[0]}</em>
+        <em>
+          <Typewriter text={myUserData.slogan[0]} />
+        </em>
       </p>
       <button onClick={downloadFile} className={styles.curriculumDownload}>
         Download my {searchCV()}

--- a/src/sections/projectSection/ProjectSection.tsx
+++ b/src/sections/projectSection/ProjectSection.tsx
@@ -8,7 +8,7 @@ import { Swiper, SwiperSlide } from "swiper/react";
 import "swiper/swiper.min.css";
 import "swiper/css/effect-fade";
 
-import ProjectCard from "../../components/projectCard";
+import ProjectCard, { ProjectData } from "../../components/projectCard";
 
 interface Props {
   myUserData: UserData;
@@ -33,7 +33,7 @@ const ProjectSection: React.FC<Props> = (props) => {
       >
         {myUserData.projects.map((item, id) => (
           <SwiperSlide key={id}>
-            <ProjectCard data={item} />
+            <ProjectCard data={item as ProjectData} />
           </SwiperSlide>
         ))}
       </Swiper>


### PR DESCRIPTION
## Summary
- Animate hero slogan with a reusable typewriter component
- Improve CV link lookup and add strict ProjectCard typings

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6897302e0d08832dae7d61e8013a4d7e