### PR TITLE
fix: make project card links functional

### DIFF
--- a/src/components/projectCard/ProjectCard.tsx
+++ b/src/components/projectCard/ProjectCard.tsx
@@ -31,21 +31,14 @@ const ProjectCard: React.FC<Props> = (props) => {
             {data.description?.split(".")[0]}
           </p>
           <div className={styles.buttons}>
-            <button
-              onClick={() => {
-                data.demo === null && alert("Errore nel caricamento");
-              }}
-              className={styles.Demo}
-            >
-              <a href={data.demo ?? undefined} target="_blank" rel="noreferrer">
+            {data.demo && (
+              <a href={data.demo} target="_blank" rel="noreferrer">
                 <FaExternalLinkAlt /> Demo
               </a>
-            </button>
-            <button className={styles.github}>
-              <a href={data.link} target="_blank" rel="noreferrer">
-                <FaGithub /> Code
-              </a>
-            </button>
+            )}
+            <a href={data.link} target="_blank" rel="noreferrer">
+              <FaGithub /> Code
+            </a>
           </div>
         </div>
       </div>

--- a/src/components/projectCard/index.module.scss
+++ b/src/components/projectCard/index.module.scss
@@ -56,7 +56,7 @@
         gap: 20px;
         margin-bottom: 20px;
 
-        button {
+        a {
           border: none;
           background-color: rgba(255, 255, 255, 0.1);
           padding: 8px 12px;
@@ -65,15 +65,8 @@
           display: flex;
           align-items: center;
           gap: 6px;
-
-          a {
-            color: white;
-            text-decoration: none;
-            display: flex;
-            align-items: center;
-            gap: 6px;
-          }
-
+          color: white;
+          text-decoration: none;
           text-transform: uppercase;
           cursor: pointer;
 


### PR DESCRIPTION
## Summary
- replace nested buttons with direct anchor links for project demos and code
- style anchors as buttons and hide demo link when absent

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68973559707c832d8a687df563cbe372