### PR TITLE
refactor: drop framer-motion for CSS-based menu animations

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,6 @@
       "dependencies": {
         "@types/react-scroll": "^1.8.7",
         "@types/swiper": "^6.0.0",
-        "framer-motion": "^10.12.12",
         "react": "^18.2.0",
         "react-css-modules": "^4.7.11",
         "react-dom": "^18.2.0",
@@ -392,21 +391,6 @@
       "engines": {
         "node": ">=6.9.0"
       }
-    },
-    "node_modules/@emotion/is-prop-valid": {
-      "version": "0.8.8",
-      "resolved": "https://registry.npmjs.org/@emotion/is-prop-valid/-/is-prop-valid-0.8.8.tgz",
-      "integrity": "sha512-u5WtneEAr5IDG2Wv65yhunPSMLIpuKsbuOktRojfrEiEvRyC85LgPMZI63cr7NUqT8ZIGdSVg8ZKGxIug4lXcA==",
-      "optional": true,
-      "dependencies": {
-        "@emotion/memoize": "0.7.4"
-      }
-    },
-    "node_modules/@emotion/memoize": {
-      "version": "0.7.4",
-      "resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.7.4.tgz",
-      "integrity": "sha512-Ja/Vfqe3HpuzRsG1oBtWTHk2PGZ7GR+2Vz5iYGelAw8dx32K0y7PjVuxK6z1nMpZOqAFsRUPCkK1YjJ56qJlgw==",
-      "optional": true
     },
     "node_modules/@esbuild/android-arm": {
       "version": "0.17.19",
@@ -2019,34 +2003,6 @@
       "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.2.7.tgz",
       "integrity": "sha512-5nqDSxl8nn5BSNxyR3n4I6eDmbolI6WT+QqR547RwxQapgjQBmtktdP+HTBb/a/zLsbzERTONyUB5pefh5TtjQ==",
       "dev": true
-    },
-    "node_modules/framer-motion": {
-      "version": "10.12.12",
-      "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-10.12.12.tgz",
-      "integrity": "sha512-DDCqp60U6hR7aUrXj/BXc/t0Sd/U4ep6w/NZQkw898K+u7s+Vv/P8yxq4WTNA86kU9QCsqOgn1Qhz2DpYK0Oag==",
-      "dependencies": {
-        "tslib": "^2.4.0"
-      },
-      "optionalDependencies": {
-        "@emotion/is-prop-valid": "^0.8.2"
-      },
-      "peerDependencies": {
-        "react": "^18.0.0",
-        "react-dom": "^18.0.0"
-      },
-      "peerDependenciesMeta": {
-        "react": {
-          "optional": true
-        },
-        "react-dom": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/framer-motion/node_modules/tslib": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
-      "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg=="
     },
     "node_modules/fs.realpath": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,6 @@
   "dependencies": {
     "@types/react-scroll": "^1.8.7",
     "@types/swiper": "^6.0.0",
-    "framer-motion": "^10.12.12",
     "react": "^18.2.0",
     "react-css-modules": "^4.7.11",
     "react-dom": "^18.2.0",

--- a/src/components/hamburgerMenu/HamburgerMenu.tsx
+++ b/src/components/hamburgerMenu/HamburgerMenu.tsx
@@ -1,8 +1,7 @@
 import styles from "./index.module.scss";
 
 import { Link } from "react-scroll/modules";
-import { motion } from "framer-motion";
-import { useEffect } from "react";
+import { useEffect, useState } from "react";
 
 interface Props {
   clickBurger: boolean;
@@ -12,89 +11,95 @@ interface Props {
 const HamburgerMenu: React.FC<Props> = (props) => {
   const { clickBurger, setClickBurger } = props;
 
-  console.log(document.body.style.overflow);
+  const [isAnimating, setIsAnimating] = useState(false);
 
   useEffect(() => {
     clickBurger
       ? (document.body.style.overflow = "hidden")
       : (document.body.style.overflow = "");
+    setIsAnimating(true);
   }, [clickBurger]);
+
+  const handleAnimationEnd = () => {
+    if (!clickBurger) {
+      setIsAnimating(false);
+    }
+  };
 
   return (
     <div
-      className={`${styles.HamburgerMenu} ${!clickBurger && styles.showMenu}`}
+      className={`${styles.HamburgerMenu} ${
+        !clickBurger && !isAnimating && styles.showMenu
+      }`}
     >
-      {clickBurger && (
-        <motion.h3
-          initial={{ y: -250 }}
-          animate={{ y: -10 }}
-          transition={{ delay: 0.2, type: "spring", stiffness: 100 }}
-        >
-          <Link
-            onClick={() => setClickBurger(false)}
-            to="about"
-            spy={true}
-            smooth={true}
-            offset={50}
-            duration={500}
+      {(clickBurger || isAnimating) && (
+        <>
+          <h3
+            className={`${styles.menuItem} ${
+              clickBurger ? styles.menuItemEnter : styles.menuItemExit
+            }`}
           >
-            About
-          </Link>
-        </motion.h3>
-      )}
-      {clickBurger && (
-        <motion.h3
-          initial={{ y: -250 }}
-          animate={{ y: -10 }}
-          transition={{ delay: 0.3, type: "spring", stiffness: 100 }}
-        >
-          <Link
-            onClick={() => setClickBurger(false)}
-            to="skill"
-            spy={true}
-            smooth={true}
-            offset={50}
-            duration={600}
+            <Link
+              onClick={() => setClickBurger(false)}
+              to="about"
+              spy={true}
+              smooth={true}
+              offset={50}
+              duration={500}
+            >
+              About
+            </Link>
+          </h3>
+          <h3
+            className={`${styles.menuItem} ${
+              clickBurger ? styles.menuItemEnter : styles.menuItemExit
+            }`}
           >
-            Skills
-          </Link>
-        </motion.h3>
-      )}
-      {clickBurger && (
-        <motion.h3
-          initial={{ y: -250 }}
-          animate={{ y: -10 }}
-          transition={{ delay: 0.4, type: "spring", stiffness: 100 }}
-        >
-          <Link
-            onClick={() => setClickBurger(false)}
-            to="projects"
-            spy={true}
-            smooth={true}
-            offset={50}
-            duration={700}
+            <Link
+              onClick={() => setClickBurger(false)}
+              to="skill"
+              spy={true}
+              smooth={true}
+              offset={50}
+              duration={600}
+            >
+              Skills
+            </Link>
+          </h3>
+          <h3
+            className={`${styles.menuItem} ${
+              clickBurger ? styles.menuItemEnter : styles.menuItemExit
+            }`}
           >
-            Projects
-          </Link>
-        </motion.h3>
-      )}
-      {clickBurger && (
-        <motion.h3
-          initial={{ y: -250 }}
-          animate={{ y: -10 }}
-          transition={{ delay: 0.5, type: "spring", stiffness: 100 }}
-        >
-          <Link
-            onClick={() => setClickBurger(false)}
-            to="contact"
-            spy={true}
-            smooth={true}
-            offset={50}
-            duration={800}
+            <Link
+              onClick={() => setClickBurger(false)}
+              to="projects"
+              spy={true}
+              smooth={true}
+              offset={50}
+              duration={700}
+            >
+              Projects
+            </Link>
+          </h3>
+          <h3
+            className={`${styles.menuItem} ${
+              clickBurger ? styles.menuItemEnter : styles.menuItemExit
+            }`}
+            onAnimationEnd={handleAnimationEnd}
           >
-            Contact
-          </Link>
-        </motion.h3>
+            <Link
+              onClick={() => setClickBurger(false)}
+              to="contact"
+              spy={true}
+              smooth={true}
+              offset={50}
+              duration={800}
+            >
+              Contact
+            </Link>
+          </h3>
+        </>
       )}
     </div>
   );

--- a/src/components/hamburgerMenu/index.module.scss
+++ b/src/components/hamburgerMenu/index.module.scss
@@ -25,3 +25,54 @@
   opacity: 0;
   z-index: -1;
 }
+
+.menuItem {
+  opacity: 1;
+  transform: translateY(-10px);
+}
+
+.menuItemEnter {
+  animation: slideDown 0.5s forwards;
+}
+
+.menuItemExit {
+  animation: slideUp 0.5s forwards;
+}
+
+.menuItem:nth-child(1) {
+  animation-delay: 0.2s;
+}
+
+.menuItem:nth-child(2) {
+  animation-delay: 0.3s;
+}
+
+.menuItem:nth-child(3) {
+  animation-delay: 0.4s;
+}
+
+.menuItem:nth-child(4) {
+  animation-delay: 0.5s;
+}
+
+@keyframes slideDown {
+  from {
+    opacity: 0;
+    transform: translateY(-250px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(-10px);
+  }
+}
+
+@keyframes slideUp {
+  from {
+    opacity: 1;
+    transform: translateY(-10px);
+  }
+  to {
+    opacity: 0;
+    transform: translateY(-250px);
+  }
+}


### PR DESCRIPTION
## Summary
- remove `framer-motion` dependency
- animate hamburger menu links with CSS keyframes and React state

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6897456485c8832d80046a483b8428b2