### PR TITLE
Fix mobile menu flash, polish visuals, remove outdated projects

### DIFF
--- a/src/components/hamburgerMenu/index.module.scss
+++ b/src/components/hamburgerMenu/index.module.scss
@@ -6,7 +6,8 @@
   position: fixed;
   top: 0;
   right: 0;
-  background-color: $primary;
+  background-color: rgba($primary, 0.95);
+  backdrop-filter: blur(4px);
   transition: all 0.5s ease-in;
   z-index: 1;
 
@@ -21,7 +22,7 @@
 }
 
 .showMenu {
-  transform: translate(500px);
+  transform: translateX(100%);
   opacity: 0;
   z-index: -1;
 }

--- a/src/components/projectCard/index.module.scss
+++ b/src/components/projectCard/index.module.scss
@@ -1,9 +1,9 @@
+@import "../../scss/variables";
 
 .ProjectCard {
   position: relative;
   width: 100%;
   max-width: 340px;
-  height: 420px;
   overflow: hidden;
   border-radius: 12px;
   box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
@@ -15,10 +15,11 @@
   }
 
   .projectImage {
-    height: 100%;
     width: 100%;
+    height: auto;
     object-fit: cover;
     transition: transform 0.4s ease;
+    display: block;
   }
 
   &:hover .projectImage {
@@ -39,22 +40,36 @@
     );
     display: flex;
     flex-direction: column;
+    justify-content: flex-end;
 
     .space {
-      height: 50%;
+      flex: 1;
     }
 
     .content {
-      height: 50%;
       display: flex;
       flex-direction: column;
       justify-content: space-between;
       padding: 0 20px 20px;
 
+      .title {
+        margin: 0 0 8px;
+        font-size: 1.4rem;
+        color: $secondary;
+      }
+
+      .description {
+        margin: 0;
+        font-size: 0.95rem;
+        line-height: 1.4;
+        color: rgba($secondary, 0.85);
+      }
+
       .buttons {
         display: flex;
         gap: 20px;
-        margin-bottom: 20px;
+        flex-wrap: wrap;
+        margin-top: 20px;
 
         a {
           border: none;

--- a/src/index.scss
+++ b/src/index.scss
@@ -1,6 +1,10 @@
 @import "scss/variables";
 @import url("https://fonts.googleapis.com/css2?family=Poppins:ital,wght@0,100;0,200;0,300;0,400;0,500;0,600;0,700;0,800;1,100;1,200;1,300;1,400;1,500;1,600;1,700;1,800&display=swap");
 
+html {
+  scroll-behavior: smooth;
+}
+
 * {
   -webkit-touch-callout: none;
   -webkit-user-select: none;
@@ -16,4 +20,14 @@ body {
   background-color: $primary;
   background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='70' height='46' viewBox='0 0 70 46'%3E%3Cg fill-rule='evenodd'%3E%3Cg fill='%23303030' fill-opacity='0.4'%3E%3Cpolygon points='68 44 62 44 62 46 56 46 56 44 52 44 52 46 46 46 46 44 40 44 40 46 38 46 38 44 32 44 32 46 26 46 26 44 22 44 22 46 16 46 16 44 12 44 12 46 6 46 6 44 0 44 0 42 8 42 8 28 6 28 6 0 12 0 12 28 10 28 10 42 18 42 18 28 16 28 16 0 22 0 22 28 20 28 20 42 28 42 28 28 26 28 26 0 32 0 32 28 30 28 30 42 38 42 38 0 40 0 40 42 48 42 48 28 46 28 46 0 52 0 52 28 50 28 50 42 58 42 58 28 56 28 56 0 62 0 62 28 60 28 60 42 68 42 68 0 70 0 70 46 68 46'/%3E%3C/g%3E%3C/g%3E%3C/svg%3E");
   color: $secondary;
+}
+
+a {
+  color: inherit;
+  text-decoration: none;
+  transition: color 0.2s ease-in-out;
+
+  &:hover {
+    color: $secondary-100;
+  }
 }

--- a/src/userData.ts
+++ b/src/userData.ts
@@ -73,22 +73,6 @@ export const myUserData: UserData = {
       link: "https://github.com/ShecktorS/MOVINTAGE",
       image: "https://i.postimg.cc/Gp0MSN7j/Progetto-senza-titolo-2.png",
     },
-    {
-      title: "Weather App",
-      description:
-        "Applicazione meteo che fornisce aggiornamenti in tempo reale basati sulle API di OpenWeather.",
-      demo: "https://weather-app-shecktors.vercel.app",
-      link: "https://github.com/ShecktorS/weather-app",
-      image: "https://via.placeholder.com/400x500.png?text=Weather+App",
-    },
-    {
-      title: "Pokedex",
-      description:
-        "Pokedex interattiva per esplorare e cercare Pokémon tramite la PokeAPI.",
-      demo: "https://pokedex-shecktors.vercel.app",
-      link: "https://github.com/ShecktorS/Pokedex",
-      image: "https://via.placeholder.com/400x500.png?text=Pokedex",
-    },
   ],
   hobbies: ["Origami", "Disegno", "Musica"],
   resources: [


### PR DESCRIPTION
## Summary
- prevent initial mobile menu flash by translating menu offscreen
- make project cards responsive and ensure action buttons are visible
- drop Weather App and Pokedex entries and refine global styling

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: ESLint couldn't find an eslint.config file)*

------
https://chatgpt.com/codex/tasks/task_e_689d962feb8c832db8c312c632e5ba98